### PR TITLE
Parse sub-types of a template class, e.g. boost iterators

### DIFF
--- a/src/templates.py
+++ b/src/templates.py
@@ -106,7 +106,7 @@ def _template_type_parse_runner(input: str, start: int) -> Tuple[TemplateType, i
         # consume remaining items and append names
         arg_type, arg_end = _template_type_parse_runner(input, arg_start)
         return TemplateType(input[start:name_end] + arg_type.name, args), arg_end
-    else
+    else:
         return TemplateType(input[start:name_end], args), arg_start
 
 

--- a/src/templates.py
+++ b/src/templates.py
@@ -54,7 +54,7 @@ class TemplateType:
         if (self.inner is None and other.inner is not None) or (self.inner is not None and other.inner is None):
             return False
         
-        return self.inner.matches(other.inner, matched_args)
+        return (self.inner is None and other.inner is None) or self.inner.matches(other.inner, matched_args)
 
 
 TEMPLATE_LIST_REGEX = re.compile("[<>,]")

--- a/src/templates.py
+++ b/src/templates.py
@@ -103,12 +103,11 @@ def _template_type_parse_runner(input: str, start: int) -> Tuple[TemplateType, i
     arg_start += 1  # Consume the '>'
 
     if arg_start < len(input):
-        # consume remaining items
+        # consume remaining items and append names
         arg_type, arg_end = _template_type_parse_runner(input, arg_start)
-        args.append(arg_type)
-        arg_start = _skip_whitespace(input, arg_end)
-
-    return TemplateType(input[start:name_end], args), arg_start
+        return TemplateType(input[start:name_end] + arg_type.name, args), arg_end
+    else
+        return TemplateType(input[start:name_end], args), arg_start
 
 
 def parse_template_type(input: str) -> TemplateType:

--- a/src/templates.py
+++ b/src/templates.py
@@ -26,7 +26,7 @@ class TemplateType:
         return self.name == "*"
 
     def __repr__(self) -> str:
-        return '<{}: {!r} [{}] -> {!r}>'.format(self.__class__.__name__, self.name, ",".join(repr(x) for x in self.args), self.inner)
+        return '<{}: {!r} [{}]> -> {!r}'.format(self.__class__.__name__, self.name, ",".join(repr(x) for x in self.args), self.inner)
 
     def __str__(self) -> str:
         if len(self.args) <= 0:

--- a/src/templates.py
+++ b/src/templates.py
@@ -102,6 +102,12 @@ def _template_type_parse_runner(input: str, start: int) -> Tuple[TemplateType, i
                                 .format("<EOF>" if arg_start >= len(input) else input[arg_start]))
     arg_start += 1  # Consume the '>'
 
+    if arg_start < len(input):
+        # consume remaining items
+        arg_type, arg_end = _template_type_parse_runner(input, arg_start)
+        args.append(arg_type)
+        arg_start = _skip_whitespace(input, arg_end)
+
     return TemplateType(input[start:name_end], args), arg_start
 
 

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -76,6 +76,44 @@ class TemplateParserTestCase(unittest.TestCase):
         self.assertTrue(vector_type.args[0].is_wildcard)
         self.assertEqual(0, len(vector_type.args[0].args))
 
+    def test_simple_list_inner_non_template(self):
+        template_type = templates.parse_template_type("test::template_class<float>::inner_class")
+
+        self.assertEqual("test::template_class", template_type.name)
+
+        self.assertEqual(1, len(template_type.args))
+
+        self.assertEqual("float", template_type.args[0].name)
+
+        self.assertEqual(0, len(template_type.args[0].args))
+
+        self.assertNotEqual(None, template_type.inner)
+
+        self.assertEqual("::inner_class", template_type.inner.name)
+
+        self.assertEqual(0, len(template_type.inner.args))
+
+    def test_simple_list_inner_simple_list(self):
+        template_type = templates.parse_template_type("test::template_class<float>::inner_class<int>")
+
+        self.assertEqual("test::template_class", template_type.name)
+
+        self.assertEqual(1, len(template_type.args))
+
+        self.assertEqual("float", template_type.args[0].name)
+
+        self.assertEqual(0, len(template_type.args[0].args))
+
+        self.assertNotEqual(None, template_type.inner)
+
+        self.assertEqual("::inner_class", template_type.inner.name)
+
+        self.assertEqual(1, len(template_type.inner.args))
+
+        self.assertEqual("int", template_type.inner.args[0].name)
+
+        self.assertEqual(0, len(template_type.inner.args[0].args))
+
     def test_missing_closing_brance(self):
         with self.assertRaises(TemplateException):
             templates.parse_template_type("test::template_class<")


### PR DESCRIPTION
Currently, the parsing stops after encountering the first template. However, e.g. Boost defines iterators on templates, see https://github.com/KindDragon/CPPDebuggerVisualizers/blob/master/VS2017/Visualizers/boost_Containers.natvis line 180. This change makes the parsing continue beyond the first template encounter.